### PR TITLE
Updated readme for the renamed SpecifyConfiguration to SpecifyBootstr…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,9 +156,9 @@ Unfortunately, even the newer versions of xUnit and NUnit seem to still require 
 ## Configuration
 Just create a class in your test assembly that inherits from the SpecifyConfiguration class. The main thing to configure is the container that the SUT factory will use:
 
-    public class SpecifyConfig : SpecifyConfiguration
+    public class SpecifyConfig : SpecifyBootstrapper
     {
-        public override IContainer GetSpecifyContainer()
+        public override IApplicationContainer CreateApplicationContainer()
         {
             return new AutofacNSubstituteContainer();
         }


### PR DESCRIPTION
…apper

Whoops, my bad the first pull request I didn't include the new overriden method.

Nice refactor though, I like the new name :-)
