### PR TITLE
Ensure that concrete classes can be mocked. Fixes #14

### DIFF
--- a/src/Samples/Specify.Samples/Domain/OrderProcessing/IPublisher.cs
+++ b/src/Samples/Specify.Samples/Domain/OrderProcessing/IPublisher.cs
@@ -1,7 +1,0 @@
-namespace Specify.Samples.Domain.OrderProcessing
-{
-	public interface IPublisher
-	{
-		void Publish<TEvent>(TEvent @event);
-	}
-}

--- a/src/Samples/Specify.Samples/Domain/OrderProcessing/OrderProcessor.cs
+++ b/src/Samples/Specify.Samples/Domain/OrderProcessing/OrderProcessor.cs
@@ -5,9 +5,9 @@ namespace Specify.Samples.Domain.OrderProcessing
     public class OrderProcessor
     {
         private readonly IInventory _inventory;
-        private readonly IPublisher _publisher;
+        private readonly Publisher _publisher;
 
-        public OrderProcessor(IInventory inventory, IPublisher publisher)
+        public OrderProcessor(IInventory inventory, Publisher publisher)
         {
             _inventory = inventory;
             _publisher = publisher;

--- a/src/Samples/Specify.Samples/Domain/OrderProcessing/Publisher.cs
+++ b/src/Samples/Specify.Samples/Domain/OrderProcessing/Publisher.cs
@@ -1,0 +1,9 @@
+namespace Specify.Samples.Domain.OrderProcessing
+{
+	public class Publisher
+    {
+        public virtual void Publish<TEvent>(TEvent @event)
+        {
+        }
+    }
+}

--- a/src/Samples/Specify.Samples/Specs/OrderProcessing/OrderProcessorSpecs.cs
+++ b/src/Samples/Specify.Samples/Specs/OrderProcessing/OrderProcessorSpecs.cs
@@ -36,7 +36,7 @@ namespace Specify.Samples.Specs.OrderProcessing
 
         public void AndThen_it_raises_an_order_submitted_event()
         {
-            The<IPublisher>().Received().Publish(Arg.Is<OrderSubmitted>(x => x.OrderNumber == _result.OrderNumber));
+            The<Publisher>().Received().Publish(Arg.Is<OrderSubmitted>(x => x.OrderNumber == _result.OrderNumber));
         }
     }
 
@@ -61,7 +61,7 @@ namespace Specify.Samples.Specs.OrderProcessing
 
         public void AndThen_it_does_not_raise_an_order_submitted_event()
         {
-            Container.Get<IPublisher>().DidNotReceive().Publish(Arg.Any<OrderSubmitted>());
+            Container.Get<Publisher>().DidNotReceive().Publish(Arg.Any<OrderSubmitted>());
         }
     }
 }

--- a/src/app/Specify/Configuration/ScenarioRunner.cs
+++ b/src/app/Specify/Configuration/ScenarioRunner.cs
@@ -15,11 +15,10 @@ namespace Specify.Configuration
             _testEngine = testEngine;
         }
 
-        public void Execute<TSut>(IScenario<TSut> testObject, string scenarioTitle = null) where TSut : class
+        public void Execute<TSut>(IScenario<TSut> scenario, string scenarioTitle = null) where TSut : class
         {
             using (var container = Configuration.ApplicationContainer.Get<IContainer>())
             {
-                var scenario = (IScenario<TSut>)container.Get(testObject.GetType());
                 scenario.SetContainer(container);
 
                 foreach (var action in Configuration.PerScenarioActions)

--- a/src/app/Specify/ContainerFor.cs
+++ b/src/app/Specify/ContainerFor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Specify.Exceptions;
 
 namespace Specify
@@ -32,7 +33,10 @@ namespace Specify
             {
                 if (_systemUnderTest == null)
                 {
-                    _systemUnderTest = Get<TSut>();
+                    var constructor = typeof(TSut).GreediestConstructor();
+                    var sut = (TSut)constructor.Invoke(constructor.GetParameters().Select(x => Get(x.ParameterType)).ToArray());
+                    Set(sut);
+                    _systemUnderTest = sut;
                 }
                 return _systemUnderTest;
             }

--- a/src/app/Specify/TestsFor.cs
+++ b/src/app/Specify/TestsFor.cs
@@ -40,8 +40,8 @@ namespace Specify
         /// </summary>
         protected TSut SUT
         {
-            get { return _sut ?? (_sut = Container.Get<TSut>()); }
-            set { _sut = value; }
+            get { return Container.SystemUnderTest; }
+            set { Container.SystemUnderTest = value; }
         }
     }
 }

--- a/src/app/Specify/TinyMockingContainer.cs
+++ b/src/app/Specify/TinyMockingContainer.cs
@@ -36,23 +36,11 @@ namespace Specify
             {
                 return GetMultiple(serviceType);
             }
-            if (serviceType.IsInterface())
+            if (serviceType.IsInterface() || serviceType.IsAbstract() || serviceType.IsClass() && !serviceType.IsSealed())
             {
-                if (!Container.CanResolve(serviceType))
+                if (!Container.CanResolve(serviceType, ResolveOptions.FailUnregisteredAndNameNotFound))
                 {
                     RegisterMock(serviceType);
-                }
-            }
-            if (serviceType.IsClass())
-            {
-                var constructor = serviceType.GreediestConstructor();
-
-                foreach (var parameterInfo in constructor.GetParameters())
-                {
-                    if (!Container.CanResolve(parameterInfo.ParameterType))
-                    {
-                        RegisterMock(parameterInfo.ParameterType);
-                    }
                 }
             }
             return base.Get(serviceType, key);

--- a/src/app/Specify/TypeExtensions.cs
+++ b/src/app/Specify/TypeExtensions.cs
@@ -188,6 +188,11 @@ namespace Specify
             return type.IsClass;
         }
 
+        internal static bool IsSealed(this Type type)
+        {
+            return type.IsSealed;
+        }
+
         internal static bool IsConcrete(this Type type)
         {
             return !type.IsAbstract && !type.IsInterface;
@@ -297,6 +302,11 @@ namespace Specify
         internal static bool IsClass(this Type type)
         {
             return type.GetTypeInfo().IsClass;
+        }
+
+        internal static bool IsSealed(this Type type)
+        {
+            return type.GetTypeInfo().IsSealed;
         }
 
         internal static bool IsConcrete(this Type type)

--- a/src/tests/Specify.Tests/Configuration/ScenarioRunnerTests.cs
+++ b/src/tests/Specify.Tests/Configuration/ScenarioRunnerTests.cs
@@ -75,11 +75,20 @@ namespace Specify.Tests.Configuration
         }
 
         [Test]
-        public void should_resolve_specification_from_child_container()
+        public void should_not_resolve_specification_from_child_container()
         {
             SUT.Execute(_spec);
 
-            _childContainer.Received(1).Get(typeof(UserStoryScenarioWithAllSupportedStepsInRandomOrder));
+            _childContainer.DidNotReceive().Get(typeof(UserStoryScenarioWithAllSupportedStepsInRandomOrder));
+        }
+
+
+        [Test]
+        public void should_assign_child_container_to_scenario()
+        {
+            SUT.Execute(_spec);
+
+            _spec.Container.SourceContainer.ShouldBe(_childContainer);
         }
     }
 }

--- a/src/tests/Specify.Tests/ContainerForTests.cs
+++ b/src/tests/Specify.Tests/ContainerForTests.cs
@@ -11,11 +11,29 @@ namespace Specify.Tests
     public class ContainerForTests
     {
         [Test]
-        public void should_use_container_to_create_sut()
+        public void should_not_use_container_to_create_sut()
         {
             var sut = this.CreateSut<ConcreteObjectWithNoConstructor>();
             var result = sut.SystemUnderTest;
-            sut.SourceContainer.Received().Get<ConcreteObjectWithNoConstructor>();
+            sut.SourceContainer.DidNotReceive().Get<ConcreteObjectWithNoConstructor>();
+        }
+
+        [Test]
+        public void should_register_sut_in_container()
+        {
+            var sut = this.CreateSut<ConcreteObjectWithNoConstructor>();
+            var result = sut.SystemUnderTest;
+            sut.SourceContainer.Received().Set(result);
+        }
+
+        [Test]
+        public void should_be_able_to_create_sut_with_concrete_constructor_retrieved_from_container()
+        {
+            var sut = this.CreateSut<ConcreteObjectWithOneConcreteConstructor>();
+            object dependency1 = new Dependency1();
+            sut.SourceContainer.Get(typeof(Dependency1)).Returns(dependency1);
+            var result = sut.SystemUnderTest;
+            result.Dependency1.ShouldBe(dependency1);
         }
 
         [Test]
@@ -26,7 +44,6 @@ namespace Specify.Tests
             var result = sut.SystemUnderTest;
 
             sut.SystemUnderTest.ShouldBeSameAs(result);
-            sut.SourceContainer.Received(1).Get<ConcreteObjectWithNoConstructor>();
         }
 
         [Test]

--- a/src/tests/Specify.Tests/ScenarioForTests.cs
+++ b/src/tests/Specify.Tests/ScenarioForTests.cs
@@ -31,11 +31,11 @@ namespace Specify.Tests
         }
 
         [Test]
-        public void should_use_context_to_create_sut()
+        public void should_not_use_context_to_create_sut()
         {
             var sut = CreateSut();
             var result = sut.SUT;
-            sut.Container.SourceContainer.Received().Get<ConcreteObjectWithNoConstructor>();
+            sut.Container.SourceContainer.DidNotReceive().Get<ConcreteObjectWithNoConstructor>();
         }
 
         [Test]
@@ -45,8 +45,17 @@ namespace Specify.Tests
             var result = sut.SUT;
 
             sut.SUT.ShouldBeSameAs(result);
-            sut.Container.SourceContainer.Received(1).Get<ConcreteObjectWithNoConstructor>();
         }
+
+        [Test]
+        public void sut_should_be_container_system_under_test()
+        {
+            var sut = CreateSut();
+            var result = sut.SUT;
+
+            sut.SUT.ShouldBeSameAs(sut.Container.SystemUnderTest);
+        }
+
         [Test]
         public void should_be_able_to_set_sut_independently()
         {
@@ -58,6 +67,7 @@ namespace Specify.Tests
 
             sut.SUT.ShouldBeSameAs(instance);
             sut.SUT.ShouldNotBeSameAs(original);
+            sut.SUT.ShouldBeSameAs(sut.Container.SystemUnderTest);
         }
 
         [Test]

--- a/src/tests/Specify.Tests/Stubs/AutoMockingStubs.cs
+++ b/src/tests/Specify.Tests/Stubs/AutoMockingStubs.cs
@@ -58,7 +58,7 @@ namespace Specify.Tests.Stubs
     {
         private int _value = 5;
 
-        public int Value
+        public virtual int Value
         {
             get { return _value; }
             set { _value = value; }


### PR DESCRIPTION
Allows `TinyMockingContainer` to mock concrete classes. Changes `ContainerFor<TSut>` to create `SystemUnderTest` using reflection and fetching of dependencies from the container.