### PR TITLE
Allow sealed classes to be in the dependency chain

### DIFF
--- a/src/Samples/Specify.Samples/Domain/OrderProcessing/Auditer.cs
+++ b/src/Samples/Specify.Samples/Domain/OrderProcessing/Auditer.cs
@@ -1,0 +1,19 @@
+﻿using Castle.Core.Logging;
+
+namespace Specify.Samples.Domain.OrderProcessing
+{
+    public sealed class Auditer
+    {
+        private readonly ILogger _logger;
+
+        public Auditer(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void Audit(Order order)
+        {
+            _logger.Info(order.PartNumber);
+        }
+    }
+}

--- a/src/Samples/Specify.Samples/Domain/OrderProcessing/OrderProcessor.cs
+++ b/src/Samples/Specify.Samples/Domain/OrderProcessing/OrderProcessor.cs
@@ -6,15 +6,18 @@ namespace Specify.Samples.Domain.OrderProcessing
     {
         private readonly IInventory _inventory;
         private readonly Publisher _publisher;
+        private readonly Auditer _auditer;
 
-        public OrderProcessor(IInventory inventory, Publisher publisher)
+        public OrderProcessor(IInventory inventory, Publisher publisher, Auditer auditer)
         {
             _inventory = inventory;
             _publisher = publisher;
+            _auditer = auditer;
         }
 
         public virtual OrderResult Process(Order order)
         {
+            _auditer.Audit(order);
             var result = new OrderResult();
 
             if (order.Quantity < 0)

--- a/src/Samples/Specify.Samples/Specs/OrderProcessing/OrderProcessorSpecs.cs
+++ b/src/Samples/Specify.Samples/Specs/OrderProcessing/OrderProcessorSpecs.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute;
+﻿using Castle.Core.Logging;
+using NSubstitute;
 using Shouldly;
 using Specify.Samples.Domain.OrderProcessing;
 
@@ -38,6 +39,11 @@ namespace Specify.Samples.Specs.OrderProcessing
         {
             The<Publisher>().Received().Publish(Arg.Is<OrderSubmitted>(x => x.OrderNumber == _result.OrderNumber));
         }
+
+        public void AndThen_it_logs_the_order_part_number()
+        {
+            The<ILogger>().Received().Info(Arg.Is<string>(x => x == "TestPart"));
+        }
     }
 
     public class orders_with_a_negative_quantity : given.the_item_is_available
@@ -62,6 +68,11 @@ namespace Specify.Samples.Specs.OrderProcessing
         public void AndThen_it_does_not_raise_an_order_submitted_event()
         {
             Container.Get<Publisher>().DidNotReceive().Publish(Arg.Any<OrderSubmitted>());
+        }
+
+        public void AndThen_it_logs_the_order_part_number()
+        {
+            The<ILogger>().Received().Info(Arg.Is<string>(x => x == "TestPart"));
         }
     }
 }

--- a/src/app/Specify.Autofac/AutofacContainer.cs
+++ b/src/app/Specify.Autofac/AutofacContainer.cs
@@ -113,20 +113,7 @@ namespace Specify.Autofac
         /// <returns><c>true</c> if this instance can resolve the specified service type; otherwise, <c>false</c>.</returns>
         public bool CanResolve(Type serviceType)
         {
-            if (serviceType.IsClass())
-            {
-                var constructor = serviceType.GreediestConstructor();
-
-                foreach (var parameterInfo in constructor.GetParameters())
-                {
-                    if (!Container.IsRegistered(parameterInfo.ParameterType))
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            return Container.IsRegistered(serviceType);
+            return serviceType.CanBeResolvedUsingContainer(x => Container.IsRegistered(x));
         }
 
         public void Dispose()

--- a/src/tests/Specify.IntegrationTests/Containers/AutoMocking/AutofacMockingContainerTests.cs
+++ b/src/tests/Specify.IntegrationTests/Containers/AutoMocking/AutofacMockingContainerTests.cs
@@ -1,4 +1,6 @@
-﻿using Autofac;
+﻿using System.Linq;
+using System.Reflection;
+using Autofac;
 using Autofac.Features.ResolveAnything;
 using Specify.Autofac;
 using Specify.Mocks;
@@ -12,7 +14,7 @@ namespace Specify.IntegrationTests.Containers.AutoMocking
         {
             var mockFactoryInstance = typeof(TMockFactory).Create<IMockFactory>();
             var builder = new ContainerBuilder();
-            builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
+            builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource(x => x.GetConstructors().Any()));
             builder.RegisterSource(new AutofacMockRegistrationHandler(mockFactoryInstance));
             var container = builder.Build();
             return new AutofacContainer(container);

--- a/src/tests/Specify.IntegrationTests/Containers/AutoMocking/MockingContainerTestsFor.cs
+++ b/src/tests/Specify.IntegrationTests/Containers/AutoMocking/MockingContainerTestsFor.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using Shouldly;
 using Specify.Tests.Stubs;
@@ -13,10 +14,24 @@ namespace Specify.IntegrationTests.Containers.AutoMocking
         where T : IContainer
     {
         [Test]
-        public void CanResolve_should_return_true_if_service_not_registered()
+        public void CanResolve_should_return_true_if_service_not_registered_and_dependency_chains_are_resolvable()
         {
             var sut = CreateSut();
             sut.CanResolve<ConcreteObjectWithOneInterfaceConstructor>().ShouldBe(true);
+            sut.CanResolve<ConcreteObjectWithOneInterfaceCollectionConstructor>().ShouldBe(true);
+            sut.CanResolve<ConcreteObjectWithOneConcreteConstructor>().ShouldBe(true);
+            sut.CanResolve<ConcreteObjectWithMultipleConstructors>().ShouldBe(true);
+            sut.CanResolve<ConcreteObjectWithOneSealedConstructorHavingNoConstructor>().ShouldBe(true);
+            sut.CanResolve<ConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor>().ShouldBe(true);
+        }
+
+        [Test]
+        public void CanResolve_should_return_false_if_service_not_registered_and_dependency_chains_are_not_resolvable()
+        {
+            var sut = CreateSut();
+            sut.CanResolve<ConcreteObjectWithPrivateConstructor>().ShouldBe(false);
+            sut.CanResolve<ConcreteObjectWithOneConcreteConstructorHavingPrivateConstructor>().ShouldBe(false);
+            sut.CanResolve<ConcreteObjectWithOneSealedConstructorHavingPrivateConstructor>().ShouldBe(false);
         }
 
         [Test]
@@ -33,6 +48,62 @@ namespace Specify.IntegrationTests.Containers.AutoMocking
             var sut = CreateSut();
             sut.Set<IDependency2, Dependency2>();
             sut.Get<IDependency2>().ShouldBeSameAs(sut.Get<IDependency2>());
+        }
+
+        [Test]
+        public void Get_should_resolve_for_all_concrete_types_where_dependency_chains_are_resolvable()
+        {
+            var sut = CreateSut();
+
+            sut.Get<SealedDependencyWithNoConstructor>().ShouldNotBeNull();
+            sut.Get<SealedDependencyWithOneInterfaceConstructor>().ShouldNotBeNull();
+
+            sut.Get<ConcreteObjectWithOneInterfaceConstructor>().ShouldNotBeNull();
+            sut.Get<ConcreteObjectWithOneInterfaceCollectionConstructor>().ShouldNotBeNull();
+            sut.Get<ConcreteObjectWithOneConcreteConstructor>().ShouldNotBeNull();
+            sut.Get<ConcreteObjectWithMultipleConstructors>().ShouldNotBeNull();
+
+            var resolvedConcreteObjectWithOneSealedConstructorHavingNoConstructor = sut.Get<ConcreteObjectWithOneSealedConstructorHavingNoConstructor>();
+            resolvedConcreteObjectWithOneSealedConstructorHavingNoConstructor.ShouldNotBeNull();
+            resolvedConcreteObjectWithOneSealedConstructorHavingNoConstructor.SealedDependencyWithNoConstructor.ShouldNotBeNull();
+
+            var resolvedConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor = sut.Get<ConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor>();
+            resolvedConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor.ShouldNotBeNull();
+            resolvedConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor.SealedDependencyWithOneInterfaceConstructor.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void Get_should_not_resolve_for_any_concrete_types_where_dependency_chains_are_not_resolvable()
+        {
+            var sut = CreateSut();
+
+            try
+            {
+                sut.Get<ConcreteObjectWithPrivateConstructor>();
+                Assert.Fail();
+            }
+            catch (Exception e)
+            {
+                e.ShouldNotBeNull();
+            }
+            try
+            {
+                sut.Get<ConcreteObjectWithOneConcreteConstructorHavingPrivateConstructor>();
+                Assert.Fail();
+            }
+            catch (Exception e)
+            {
+                e.ShouldNotBeNull();
+            }
+            try
+            {
+                sut.Get<ConcreteObjectWithOneSealedConstructorHavingPrivateConstructor>();
+                Assert.Fail();
+            }
+            catch (Exception e)
+            {
+                e.ShouldNotBeNull();
+            }
         }
     }
 }

--- a/src/tests/Specify.Tests/Stubs/AutoMockingStubs.cs
+++ b/src/tests/Specify.Tests/Stubs/AutoMockingStubs.cs
@@ -32,6 +32,48 @@ namespace Specify.Tests.Stubs
             Dependency1 = dependency1;
         }
     }
+    class ConcreteObjectWithOneSealedConstructorHavingNoConstructor
+    {
+        public readonly SealedDependencyWithNoConstructor SealedDependencyWithNoConstructor;
+
+        public ConcreteObjectWithOneSealedConstructorHavingNoConstructor(SealedDependencyWithNoConstructor sealedDependencyWithNoConstructor)
+        {
+            SealedDependencyWithNoConstructor = sealedDependencyWithNoConstructor;
+        }
+    }
+    class ConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor
+    {
+        public readonly SealedDependencyWithOneInterfaceConstructor SealedDependencyWithOneInterfaceConstructor;
+
+        public ConcreteObjectWithOneSealedConstructorHavingOneInterfaceConstructor(SealedDependencyWithOneInterfaceConstructor sealedDependencyWithOneInterfaceConstructor)
+        {
+            SealedDependencyWithOneInterfaceConstructor = sealedDependencyWithOneInterfaceConstructor;
+        }
+    }
+    class ConcreteObjectWithPrivateConstructor
+    {
+        private ConcreteObjectWithPrivateConstructor()
+        {
+        }
+    }
+    class ConcreteObjectWithOneConcreteConstructorHavingPrivateConstructor
+    {
+        public readonly ConcreteObjectWithPrivateConstructor ConcreteObjectWithPrivateConstructor;
+
+        public ConcreteObjectWithOneConcreteConstructorHavingPrivateConstructor(ConcreteObjectWithPrivateConstructor concreteObjectWithPrivateConstructor)
+        {
+            ConcreteObjectWithPrivateConstructor = concreteObjectWithPrivateConstructor;
+        }
+    }
+    class ConcreteObjectWithOneSealedConstructorHavingPrivateConstructor
+    {
+        public readonly SealedDependencyWithPrivateConstructor SealedDependencyWithPrivateConstructor;
+
+        public ConcreteObjectWithOneSealedConstructorHavingPrivateConstructor(SealedDependencyWithPrivateConstructor sealedDependencyWithPrivateConstructor)
+        {
+            SealedDependencyWithPrivateConstructor = sealedDependencyWithPrivateConstructor;
+        }
+    }
 
     class ConcreteObjectWithMultipleConstructors
     {
@@ -70,6 +112,30 @@ namespace Specify.Tests.Stubs
     }
     class Dependency3 : IDependency3 {}
     class Dependency4 : IDependency3 {}
+
+    sealed class SealedDependencyWithNoConstructor { }
+
+    sealed class SealedDependencyWithOneInterfaceConstructor
+    {
+        public readonly IDependency1 Dependency1;
+
+        public SealedDependencyWithOneInterfaceConstructor(IDependency1 dependency1)
+        {
+            Dependency1 = dependency1;
+        }
+    }
+
+    sealed class SealedDependencyWithPrivateConstructor
+    {
+        private SealedDependencyWithPrivateConstructor()
+        {
+        }
+
+        public SealedDependencyWithPrivateConstructor Create()
+        {
+            return new SealedDependencyWithPrivateConstructor();
+        }
+    }
 
     public interface IDependency2
     {


### PR DESCRIPTION
Thanks for making these changes @mwhelan.

Here's something to start with regarding the sealed class scenario. The `bool CanResolve(Type type)` method in `TinyMockingContainer` and `AutofacContainer` still need to be changed to take this into consideration. Only if a dependency in the chain cannot be mocked then they should return false. Otherwise they should return true.