### PR TITLE
Updated Packages and Made Host class public

### DIFF
--- a/src/Samples/Specify.Samples/Specify.Samples.csproj
+++ b/src/Samples/Specify.Samples/Specify.Samples.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netstandard1.6</TargetFrameworks>
     <AssemblyName>Specify.Samples</AssemblyName>
     <PackageId>Specify.Samples</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.2</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -17,11 +15,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.0" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
@@ -42,5 +40,4 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/src/app/Specify.Autofac/Specify.Autofac.csproj
+++ b/src/app/Specify.Autofac/Specify.Autofac.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netstandard1.6</TargetFrameworks>
     <Description>Specify is a .Net testing library that builds on top of BDDfy from TestStack</Description>
-    <Copyright>Copyright 2016 Michael Whelan</Copyright>
+    <Copyright>Copyright 2017 Michael Whelan</Copyright>
     <VersionPrefix>2.2.0</VersionPrefix>
     <AssemblyName>Specify.Autofac</AssemblyName>
     <PackageId>Specify.Autofac</PackageId>
@@ -24,12 +24,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.6.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
     <Reference Include="System" />
@@ -41,7 +42,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/app/Specify/Host.cs
+++ b/src/app/Specify/Host.cs
@@ -5,19 +5,19 @@ using Specify.Logging;
 
 namespace Specify
 {
-    internal static class Host
+    public static class Host
     {
         public static readonly IBootstrapSpecify Configuration;
         private static readonly ScenarioRunner _scenarioRunner;
 
-        public static void Specify<TSut>(IScenario<TSut> testObject, string scenarioTitle = null) where TSut : class
+        internal static void Specify<TSut>(IScenario<TSut> testObject, string scenarioTitle = null) where TSut : class
         {
             _scenarioRunner.Execute(testObject, scenarioTitle);
         }
 
         static Host()
         {
-#if NET45
+#if NET46
             "Host".Log().DebugFormat("Registering AppDomain DomainUnload event");
             AppDomain.CurrentDomain.DomainUnload += (sender, e) => {
                 _scenarioRunner.AfterAllScenarios();

--- a/src/app/Specify/Specify.csproj
+++ b/src/app/Specify/Specify.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netstandard1.6</TargetFrameworks>
     <Description>Specify is a .Net testing library that builds on top of BDDfy from TestStack</Description>
-    <Copyright>Copyright 2016 Michael Whelan</Copyright>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <Copyright>Copyright 2017 Michael Whelan</Copyright>
+    <VersionPrefix>2.3.0</VersionPrefix>
     <Authors>Michael Whelan</Authors>
     <AssemblyName>Specify</AssemblyName>
     <PackageId>Specify</PackageId>
@@ -24,10 +24,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Xml" />
@@ -40,8 +42,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/app/Specify/TypeExtensions.cs
+++ b/src/app/Specify/TypeExtensions.cs
@@ -137,7 +137,7 @@ namespace Specify
         }
     }
 
-#if NET45
+#if NET46
     internal static partial class TypeExtensions
     {
         /// <summary>

--- a/src/app/Specify/lib/AssemblyTypeResolver.cs
+++ b/src/app/Specify/lib/AssemblyTypeResolver.cs
@@ -1,4 +1,4 @@
-﻿#if NET45
+﻿#if NET46
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/tests/Specify.IntegrationTests/Specify.IntegrationTests.csproj
+++ b/src/tests/Specify.IntegrationTests/Specify.IntegrationTests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netstandard1.6</TargetFrameworks>
     <AssemblyName>Specify.IntegrationTests</AssemblyName>
     <PackageId>Specify.IntegrationTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.2</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -22,14 +20,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Autofac" Version="4.6.1" />
-    <PackageReference Include="FakeItEasy" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="FakeItEasy" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
+    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>

--- a/src/tests/Specify.Tests/Specify.Tests.csproj
+++ b/src/tests/Specify.Tests/Specify.Tests.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46;netstandard1.6</TargetFrameworks>
     <AssemblyName>Specify.Tests</AssemblyName>
     <PackageId>Specify.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50;portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.2</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -27,15 +25,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Autofac" Version="4.6.1" />
-    <PackageReference Include="FakeItEasy" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Autofac" Version="4.6.2" />
+    <PackageReference Include="FakeItEasy" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.1" />
+    <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="NLog" Version="5.0.0-beta09" />
-    <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="Shouldly" Version="2.8.3" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
As discussed today:
- Updated all packages to latest versions.
- Updated conditional build statements to correct for version changes.
- Updated csproj files.
- Made Host public (and made Specify() method internal as you proposed), this now allows us to access Host.Container.ApplicationContainer in order to dispose it after running tests.  This allows us to get the OnRelease action triggered on SingleInstance items inside the container consistently.